### PR TITLE
Update badbet.txt to new version of Marlowe Playground

### DIFF
--- a/badbet.txt
+++ b/badbet.txt
@@ -69,7 +69,19 @@ When
                                             Close 
                                         )
                                     )
-                                    Close 
+                                    (Pay
+                                        (Role "outbet")
+                                        (Party (Role "player1"))
+                                        (Token "" "")
+                                        (Constant 10)
+                                        (Pay
+                                            (Role "outbet")
+                                            (Party (Role "player2"))
+                                            (Token "" "")
+                                            (Constant 10)
+                                            Close 
+                                        )
+                                    )
                                 )]
                             100 Close 
                         )]

--- a/badbet.txt
+++ b/badbet.txt
@@ -1,10 +1,7 @@
 When
     [Case
         (Deposit
-            (AccountId
-                0
-                (PK "ourbet")
-            )
+            (Role "outbet")
             (Role "player1")
             (Token "" "")
             (Constant 15)
@@ -12,10 +9,7 @@ When
         (When
             [Case
                 (Deposit
-                    (AccountId
-                        0
-                        (PK "ourbet")
-                    )
+                    (Role "outbet")
                     (Role "player2")
                     (Token "" "")
                     (Constant 15)
@@ -61,20 +55,14 @@ When
                                             (Constant 1)
                                         )
                                         (Pay
-                                            (AccountId
-                                                0
-                                                (PK "ourbet")
-                                            )
+                                            (Role "outbet")
                                             (Party (Role "player1"))
                                             (Token "" "")
                                             (Constant 30)
                                             Close 
                                         )
                                         (Pay
-                                            (AccountId
-                                                0
-                                                (PK "ourbet")
-                                            )
+                                            (Role "outbet")
                                             (Party (Role "player2"))
                                             (Token "" "")
                                             (Constant 30)
@@ -87,16 +75,6 @@ When
                         )]
                     100 Close 
                 )]
-            30
-            (Pay
-                (AccountId
-                    0
-                    (PK "ourbet")
-                )
-                (Party (Role "player1"))
-                (Token "" "")
-                (Constant 15)
-                Close 
-            )
+            30 Close 
         )]
     20 Close 


### PR DESCRIPTION
Previous Marlowe code no longer compiles in Marlowe Playground.
It seems that we need to replace "Public Key" "outbet" by "Role" "outbet" to make it work.
Thanks for this tutorial.